### PR TITLE
Issue #137 - ctools update

### DIFF
--- a/ding_campaign.make
+++ b/ding_campaign.make
@@ -3,7 +3,7 @@ api = 2
 
 ; Projects
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.5"
 
 projects[features][subdir] = "contrib"
 projects[features][version] = "2.0"


### PR DESCRIPTION
Updated ctools which fixes PHP 5.3 warnings.